### PR TITLE
feat: PresignedUrl 이미지 크기 제한 및 Lambda 썸네일 생성 (#3)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,10 +4,11 @@ knowledge_base:
     learnings:
         scope: auto
     file_patterns:
-        - "docs/**"
+        - "CLAUDE.md"
+        - ".github/git-commit-instructions.md"
 
 reviews:
-    profile: "chill"
+    profile: "assertive"
     high_level_summary: true
     poem: false
     collapse_walkthrough: false
@@ -22,23 +23,115 @@ reviews:
         - "!gradle/wrapper/**"
         - "!gradlew"
         - "!gradlew.bat"
+        - "!**/.terraform/**"
+        - "!terraform/.terraform.lock.hcl"
 
     path_instructions:
         -   path: "**"
             instructions: |
-                이 프로젝트는 Kotlin + Spring Boot 기반의 멀티모듈 프로젝트로, 헥사고날 아키텍처를 따릅니다.
-                모듈 구성: zzan-core(공통), zzan-user, zzan-feed, zzan-liquor, zzan-place, zzan-infra, zzan-app
-                각 모듈은 adapter(in/out), application(port/service), domain 레이어로 구성됩니다.
-                - 비즈니스 로직은 domain 및 application/service 레이어에만 위치해야 합니다.
-                - 외부 의존성(JPA, Redis 등)은 adapter/out 레이어에만 위치해야 합니다.
-                - 모듈 간 직접 의존은 지양하고, zzan-infra의 어댑터를 통해 연결합니다.
-                - 모듈 간 이벤트는 zzan-core의 event 패키지에 정의된 Spring Event로 통신합니다.
+                이 프로젝트는 Kotlin + Spring Boot 기반의 7개 멀티모듈 프로젝트로, 헥사고날 아키텍처를 따릅니다.
+                모듈 구성: zzan-core(공통 인프라), zzan-user, zzan-feed, zzan-liquor, zzan-place, zzan-infra(외부 서비스), zzan-app(조립)
+                각 도메인 모듈은 adapter(in/out), application(port/in, port/out, service), domain(vo/) 레이어로 구성됩니다.
 
-        -   path: "**/*Entity.kt"
-            instructions: "연관관계 매핑(FetchType, cascade)과 소프트 딜리트(@SQLRestriction) 적용 여부를 확인하세요."
+                [의존성 규칙]
+                - 도메인 모듈 간 직접 의존 금지. 크로스 모듈 통신은 zzan-infra 어댑터 또는 zzan-core 이벤트를 통해서만 가능합니다.
+                - 비즈니스 로직은 domain/ 또는 application/service/ 레이어에만 위치해야 합니다.
+                - Spring, JPA, Redis 등 외부 기술 의존성은 adapter/out/ 레이어에만 위치해야 합니다.
+                - application/service/는 port/out/ 인터페이스만 의존해야 하며, 구현체(JpaRepository, Redis 등)를 직접 참조하면 안 됩니다.
 
-        -   path: "**/*JpaRepository.kt"
-            instructions: "N+1 문제와 커서 페이지네이션 쿼리 조건을 확인하세요."
+                [공통 패턴]
+                - ID: ULID 사용 (26자 고정), UUID 사용 시 지적해주세요.
+                - 예외: CustomException(HttpStatus, message) 사용. 표준 예외를 직접 던지면 안 됩니다.
+                - API 응답: ApiResponse.ok(data) / ApiResponse.error(message) 래퍼 사용.
+                - 페이지네이션: 커서 기반(CursorPageRequest/CursorPageResponse). Offset 기반 페이지네이션 사용 시 지적해주세요.
+
+        -   path: "**/domain/**/*.kt"
+            instructions: |
+                도메인 모델 검토 기준:
+                - Spring, JPA 등 프레임워크 의존성이 없어야 합니다 (순수 Kotlin 클래스).
+                - Value Object(vo/)는 생성자에서 유효성 검증을 수행해야 합니다.
+                - 도메인 로직(상태 변경, 비즈니스 규칙)이 서비스 레이어가 아닌 도메인 모델에 구현되었는지 확인하세요.
+
+        -   path: "**/application/service/**/*.kt"
+            instructions: |
+                서비스 레이어 검토 기준:
+                - 클래스 레벨 @Transactional(readOnly = true), 쓰기 메서드에 @Transactional 개별 적용 패턴을 따르는지 확인하세요.
+                - JpaRepository, Redis 등 구현체를 직접 주입받지 않고, port/out/ 인터페이스만 사용하는지 확인하세요.
+                - 트랜잭션 경계 내에서 이벤트를 발행하는지, 발행 후 트랜잭션 커밋 보장이 필요한지 검토하세요.
+                - 단일 책임 원칙: 하나의 서비스가 너무 많은 Repository를 주입받으면 분리를 고려하세요.
+
+        -   path: "**/adapter/in/**/*.kt"
+            instructions: |
+                입력 어댑터(컨트롤러/스케줄러) 검토 기준:
+                - 인증이 필요한 엔드포인트는 @CurrentUser 어노테이션으로 userId를 주입받아야 합니다.
+                - 비즈니스 로직이 없어야 하며, UseCase 인터페이스(port/in)만 호출해야 합니다.
+                - 요청 DTO에 @Valid 및 Bean Validation 어노테이션이 적절히 적용되었는지 확인하세요.
+                - GET 요청은 인증 없이 허용, POST/PUT/DELETE는 인증 필요(SecurityConfig 정책 기준).
+
+        -   path: "**/adapter/out/entity/**/*.kt"
+            instructions: |
+                JPA 엔티티 검토 기준:
+                - 소프트 딜리트가 필요한 엔티티는 AuditableEntity를 상속해야 합니다 (@SQLRestriction("deleted_at IS NULL") 자동 적용).
+                - 연관관계 FetchType 기본값(LAZY) 준수 여부를 확인하세요. EAGER 사용 시 반드시 이유가 명확해야 합니다.
+                - cascade 설정이 의도치 않은 삭제/저장을 유발하지 않는지 확인하세요.
+                - 도메인 모델과의 변환 메서드(toDomain(), of() 등)에서 필드 누락이 없는지 확인하세요.
+
+        -   path: "**/adapter/out/jpa/**/*.kt"
+            instructions: |
+                JPA Repository 검토 기준:
+                - N+1 쿼리 위험이 있는 경우 @EntityGraph 또는 fetch join 사용을 권장하세요.
+                - 커서 기반 페이지네이션: 쿼리에서 cursor가 null이면 전체 조회, null이 아니면 cursor 이후 데이터만 조회하는 조건이 있어야 합니다.
+                - 대량 처리 쿼리에 적절한 인덱스 힌트 또는 조건이 있는지 확인하세요.
+
+        -   path: "**/application/port/**/*.kt"
+            instructions: |
+                포트 인터페이스 검토 기준:
+                - 인터페이스에 구현 세부사항(JPA, Redis 등 기술 용어)이 노출되지 않아야 합니다.
+                - 메서드 시그니처가 도메인 모델을 기준으로 정의되어야 합니다.
+
+        -   path: "**/adapter/out/event/**/*.kt"
+            instructions: |
+                이벤트 발행 어댑터 검토 기준:
+                - Spring ApplicationEventPublisher를 사용하는지 확인하세요.
+                - FeedEventPublisher 등 port/out 인터페이스를 구현해야 합니다.
+
+        -   path: "zzan-core/src/main/kotlin/com/zzan/core/event/**/*.kt"
+            instructions: |
+                도메인 이벤트 정의 검토 기준:
+                - 이벤트는 data class로 불변 상태를 유지해야 합니다.
+                - 이벤트 소비자(@TransactionalEventListener + @Async)가 필요한 정보를 이벤트에 모두 포함하는지 확인하세요.
+                - 이벤트 처리 실패 시 재처리 전략(retry, DLQ)이 고려되었는지 검토하세요.
+
+        -   path: "zzan-core/src/main/kotlin/com/zzan/core/security/**/*.kt"
+            instructions: |
+                보안 설정 검토 기준:
+                - SecurityConfig 변경 시 인증/인가 정책의 의도치 않은 변경이 없는지 꼼꼼히 검토하세요.
+                - JWT 토큰 검증 로직에서 만료, 서명 검증이 모두 처리되는지 확인하세요.
+                - 민감 정보(JWT secret, AWS key 등)가 코드에 하드코딩되지 않았는지 반드시 확인하세요.
+
+        -   path: "zzan-infra/**/*.kt"
+            instructions: |
+                인프라 어댑터 검토 기준:
+                - 외부 API(Kakao, AWS S3) 호출 실패 시 적절한 예외 처리와 fallback이 있는지 확인하세요.
+                - API 키, 시크릿 등 민감 정보는 반드시 환경 변수로 주입받아야 합니다.
+                - 외부 API 응답을 도메인 모델이나 포트 인터페이스의 타입으로 변환하는 책임이 이 레이어에 있어야 합니다.
+
+        -   path: "**/src/test/**/*.kt"
+            instructions: |
+                테스트 검토 기준:
+                - MockK(@MockK, @InjectMockKs, @ExtendWith(MockKExtension::class)) 패턴을 따르는지 확인하세요.
+                - @Nested + @DisplayName으로 테스트 케이스를 구조화하는지 확인하세요.
+                - 테스트 픽스처(도메인 객체 생성)가 실제 유효성 검증 조건을 만족하는지 확인하세요.
+                - 서비스 테스트는 Spring 컨텍스트 없이 순수 단위 테스트로 작성되어야 합니다.
+
+        -   path: "build.gradle.kts"
+            instructions: "의존성 추가 시 모듈 간 순환 의존이 발생하지 않는지, 도메인 모듈이 다른 도메인 모듈을 의존하지 않는지 확인하세요."
+
+        -   path: "**/build.gradle.kts"
+            instructions: "새 의존성 추가 시 zzan-core에 이미 api()로 선언된 의존성과 중복되지 않는지 확인하세요."
+
+        -   path: "terraform/**"
+            instructions: "인프라 변경 시 환경 변수 및 시크릿이 코드에 하드코딩되지 않았는지 확인하세요."
 
     auto_review:
         enabled: true

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ Thumbs.db
 
 ### environment variables ###
 .env
+
+### zip files ###
+*.zip

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,0 +1,118 @@
+locals {
+    pillow_layer_arn = "arn:aws:lambda:ap-northeast-2:770693421928:layer:Klayers-p312-Pillow:10"
+
+    lambda_functions = {
+        image_processor = {
+            handler     = "index.handler"
+            runtime     = "python3.12"
+            description = "이미지 크기 검증 및 썸네일 생성"
+            environment = {
+                MAX_SIZE_BYTES = "20971520" # 20MB
+            }
+        }
+    }
+}
+
+# Lambda 코드 압축
+data "archive_file" "lambda" {
+    for_each    = local.lambda_functions
+    type        = "zip"
+    source_dir  = "${path.module}/lambda/${each.key}"
+    output_path = "${path.module}/lambda/${each.key}.zip"
+}
+
+# IAM Role - Lambda
+resource "aws_iam_role" "lambda" {
+    name = "${var.project_name}-lambda-role"
+
+    assume_role_policy = jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+            {
+                Action = "sts:AssumeRole"
+                Effect = "Allow"
+                Principal = {
+                    Service = "lambda.amazonaws.com"
+                }
+            }
+        ]
+    })
+}
+
+# IAM Policy - Lambda가 S3 접근
+resource "aws_iam_role_policy" "lambda_s3" {
+    name = "${var.project_name}-lambda-s3-policy"
+    role = aws_iam_role.lambda.id
+
+    policy = jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+            {
+                Effect = "Allow"
+                Action = [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject"
+                ]
+                Resource = "arn:aws:s3:::${var.bucket_name}/*"
+            }
+        ]
+    })
+}
+
+# IAM Policy - CloudWatch 로그
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+    role       = aws_iam_role.lambda.name
+    policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# Lambda Function
+resource "aws_lambda_function" "functions" {
+    for_each         = local.lambda_functions
+    filename         = data.archive_file.lambda[each.key].output_path
+    source_code_hash = data.archive_file.lambda[each.key].output_base64sha256
+    function_name    = "${var.project_name}-${each.key}"
+    role             = aws_iam_role.lambda.arn
+    handler          = each.value.handler
+    runtime          = each.value.runtime
+    description      = each.value.description
+
+    layers = [local.pillow_layer_arn]
+
+    environment {
+        variables = each.value.environment
+    }
+
+    tags = {
+        Name = "${var.project_name}-${each.key}"
+    }
+}
+
+# S3 트리거
+resource "aws_s3_bucket_notification" "image_upload" {
+    bucket = var.bucket_name
+
+    lambda_function {
+        lambda_function_arn = aws_lambda_function.functions["image_processor"].arn
+        events = ["s3:ObjectCreated:*"]
+        filter_prefix       = "feed-images/"
+    }
+
+    lambda_function {
+        lambda_function_arn = aws_lambda_function.functions["image_processor"].arn
+        events = ["s3:ObjectCreated:*"]
+        filter_prefix       = "user-profile-images/"
+    }
+
+    depends_on = [aws_lambda_permission.s3_invoke]
+}
+
+# Lambda가 S3에서 호출될 수 있도록 권한 부여
+resource "aws_lambda_permission" "s3_invoke" {
+    for_each      = local.lambda_functions
+    statement_id  = "AllowS3Invoke-${each.key}"
+    action        = "lambda:InvokeFunction"
+    function_name = aws_lambda_function.functions[each.key].function_name
+    principal     = "s3.amazonaws.com"
+    source_arn    = "arn:aws:s3:::${var.bucket_name}"
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,111 +1,113 @@
 locals {
-    pillow_layer_arn = "arn:aws:lambda:${var.aws_region}:770693421928:layer:Klayers-p312-Pillow:10"
+  pillow_layer_arn = "arn:aws:lambda:${var.aws_region}:770693421928:layer:Klayers-p312-Pillow:10"
 
-    lambda_functions = {
-        image_processor = {
-            handler     = "index.handler"
-            runtime     = "python3.12"
-            description = "이미지 크기 검증 및 썸네일 생성"
-            environment = {
-                MAX_SIZE_BYTES = "20971520" # 20MB
-            }
-        }
+  lambda_functions = {
+    image_processor = {
+      handler     = "index.handler"
+      runtime     = "python3.12"
+      description = "이미지 크기 검증 및 썸네일 생성"
+      environment = {
+        MAX_SIZE_BYTES = "20971520" # 20MB
+      }
     }
+  }
 }
 
 # Lambda 코드 압축
 data "archive_file" "lambda" {
-    for_each    = local.lambda_functions
-    type        = "zip"
-    source_dir  = "${path.module}/lambda/${each.key}"
-    output_path = "${path.module}/lambda/${each.key}.zip"
+  for_each    = local.lambda_functions
+  type        = "zip"
+  source_dir  = "${path.module}/lambda/${each.key}"
+  output_path = "${path.module}/lambda/${each.key}.zip"
 }
 
 # IAM Role - Lambda
 resource "aws_iam_role" "lambda" {
-    name = "${var.project_name}-lambda-role"
+  name = "${var.project_name}-lambda-role"
 
-    assume_role_policy = jsonencode({
-        Version = "2012-10-17"
-        Statement = [
-            {
-                Action = "sts:AssumeRole"
-                Effect = "Allow"
-                Principal = {
-                    Service = "lambda.amazonaws.com"
-                }
-            }
-        ]
-    })
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
 }
 
 # IAM Policy - Lambda가 S3 접근
 resource "aws_iam_role_policy" "lambda_s3" {
-    name = "${var.project_name}-lambda-s3-policy"
-    role = aws_iam_role.lambda.id
+  name = "${var.project_name}-lambda-s3-policy"
+  role = aws_iam_role.lambda.id
 
-    policy = jsonencode({
-        Version = "2012-10-17"
-        Statement = [
-            {
-                Effect = "Allow"
-                Action = [
-                    "s3:GetObject",
-                    "s3:PutObject",
-                    "s3:DeleteObject"
-                ]
-                Resource = "arn:aws:s3:::${var.bucket_name}/*"
-            }
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject"
         ]
-    })
+        Resource = "arn:aws:s3:::${var.bucket_name}/*"
+      }
+    ]
+  })
 }
 
 # IAM Policy - CloudWatch 로그
 resource "aws_iam_role_policy_attachment" "lambda_logs" {
-    role       = aws_iam_role.lambda.name
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 # Lambda Function
 resource "aws_lambda_function" "functions" {
-    for_each         = local.lambda_functions
-    filename         = data.archive_file.lambda[each.key].output_path
-    source_code_hash = data.archive_file.lambda[each.key].output_base64sha256
-    function_name    = "${var.project_name}-${each.key}"
-    role             = aws_iam_role.lambda.arn
-    handler          = each.value.handler
-    runtime          = each.value.runtime
-    description      = each.value.description
+  for_each         = local.lambda_functions
+  filename         = data.archive_file.lambda[each.key].output_path
+  source_code_hash = data.archive_file.lambda[each.key].output_base64sha256
+  function_name    = "${var.project_name}-${each.key}"
+  role             = aws_iam_role.lambda.arn
+  handler          = each.value.handler
+  runtime          = each.value.runtime
+  description      = each.value.description
+  timeout          = 30
+  memory_size      = 512
 
-    layers = [local.pillow_layer_arn]
+  layers = [local.pillow_layer_arn]
 
-    environment {
-        variables = each.value.environment
-    }
+  environment {
+    variables = each.value.environment
+  }
 
-    tags = {
-        Name = "${var.project_name}-${each.key}"
-    }
+  tags = {
+    Name = "${var.project_name}-${each.key}"
+  }
 }
 
 # S3 트리거
 resource "aws_s3_bucket_notification" "image_upload" {
-    bucket = var.bucket_name
+  bucket = var.bucket_name
 
-    lambda_function {
-        lambda_function_arn = aws_lambda_function.functions["image_processor"].arn
-        events              = ["s3:ObjectCreated:*"]
-    }
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.functions["image_processor"].arn
+    events = ["s3:ObjectCreated:*"]
+  }
 
-    depends_on = [aws_lambda_permission.s3_invoke]
+  depends_on = [aws_lambda_permission.s3_invoke]
 }
 
 # Lambda가 S3에서 호출될 수 있도록 권한 부여
 resource "aws_lambda_permission" "s3_invoke" {
-    for_each      = local.lambda_functions
-    statement_id  = "AllowS3Invoke-${each.key}"
-    action        = "lambda:InvokeFunction"
-    function_name = aws_lambda_function.functions[each.key].function_name
-    principal     = "s3.amazonaws.com"
-    source_arn    = "arn:aws:s3:::${var.bucket_name}"
+  for_each      = local.lambda_functions
+  statement_id  = "AllowS3Invoke-${each.key}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.functions[each.key].function_name
+  principal     = "s3.amazonaws.com"
+  source_arn    = "arn:aws:s3:::${var.bucket_name}"
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,5 +1,5 @@
 locals {
-    pillow_layer_arn = "arn:aws:lambda:ap-northeast-2:770693421928:layer:Klayers-p312-Pillow:10"
+    pillow_layer_arn = "arn:aws:lambda:${var.aws_region}:770693421928:layer:Klayers-p312-Pillow:10"
 
     lambda_functions = {
         image_processor = {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -94,14 +94,7 @@ resource "aws_s3_bucket_notification" "image_upload" {
 
     lambda_function {
         lambda_function_arn = aws_lambda_function.functions["image_processor"].arn
-        events = ["s3:ObjectCreated:*"]
-        filter_prefix       = "feed-images/"
-    }
-
-    lambda_function {
-        lambda_function_arn = aws_lambda_function.functions["image_processor"].arn
-        events = ["s3:ObjectCreated:*"]
-        filter_prefix       = "user-profile-images/"
+        events              = ["s3:ObjectCreated:*"]
     }
 
     depends_on = [aws_lambda_permission.s3_invoke]

--- a/terraform/lambda/image_processor/index.py
+++ b/terraform/lambda/image_processor/index.py
@@ -1,0 +1,55 @@
+import boto3
+import os
+from PIL import Image
+import io
+
+s3 = boto3.client('s3')
+
+MAX_SIZE_BYTES = int(os.environ.get('MAX_SIZE_BYTES', 20 * 1024 * 1024))  # 20MB
+THUMBNAIL_SIZE = (300, 300)
+
+
+def handler(event, context):
+    record = event['Records'][0]
+    bucket = record['s3']['bucket']['name']
+    key = record['s3']['object']['key']
+    size = record['s3']['object']['size']
+
+    print(f"Processing: {key}, size: {size} bytes")
+
+    # 썸네일이 트리거한 경우 무시
+    if key.startswith("thumbnail/"):
+        return {"status": "skipped"}
+
+    # 크기 초과 시 삭제
+    if size > MAX_SIZE_BYTES:
+        print(f"File too large ({size} bytes), deleting: {key}")
+        s3.delete_object(Bucket=bucket, Key=key)
+        return {"status": "deleted", "reason": "file too large"}
+
+    # 썸네일 생성
+    response = s3.get_object(Bucket=bucket, Key=key)
+    image_data = response['Body'].read()
+
+    image = Image.open(io.BytesIO(image_data))
+    image.thumbnail(THUMBNAIL_SIZE)
+
+    if image.mode in ("RGBA", "P"):
+        image = image.convert("RGB")
+
+    buffer = io.BytesIO()
+    image.save(buffer, format="JPEG", quality=85)
+    buffer.seek(0)
+
+    # feed-images/uuid.jpg -> thumbnail/feed-images/uuid.jpg
+    thumbnail_key = "thumbnail/" + key
+
+    s3.put_object(
+        Bucket=bucket,
+        Key=thumbnail_key,
+        Body=buffer,
+        ContentType="image/jpeg"
+    )
+
+    print(f"Thumbnail created: {thumbnail_key}")ㅇ
+    return {"status": "success", "thumbnail_key": thumbnail_key}

--- a/terraform/lambda/image_processor/index.py
+++ b/terraform/lambda/image_processor/index.py
@@ -51,5 +51,5 @@ def handler(event, context):
         ContentType="image/jpeg"
     )
 
-    print(f"Thumbnail created: {thumbnail_key}")ㅇ
+    print(f"Thumbnail created: {thumbnail_key}")
     return {"status": "success", "thumbnail_key": thumbnail_key}

--- a/terraform/lambda/image_processor/index.py
+++ b/terraform/lambda/image_processor/index.py
@@ -1,5 +1,6 @@
 import boto3
 import os
+import urllib.parse
 from PIL import Image
 import io
 
@@ -7,49 +8,62 @@ s3 = boto3.client('s3')
 
 MAX_SIZE_BYTES = int(os.environ.get('MAX_SIZE_BYTES', 20 * 1024 * 1024))  # 20MB
 THUMBNAIL_SIZE = (300, 300)
+ALLOWED_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp'} # 이미지 확장자만 허용
 
 
 def handler(event, context):
-    record = event['Records'][0]
-    bucket = record['s3']['bucket']['name']
-    key = record['s3']['object']['key']
-    size = record['s3']['object']['size']
+    results = []
+    for record in event['Records']:
+        bucket = record['s3']['bucket']['name']
+        key = urllib.parse.unquote_plus(record['s3']['object']['key'])
+        size = record['s3']['object']['size']
 
-    print(f"Processing: {key}, size: {size} bytes")
+        print(f"Processing: {key}, size: {size} bytes")
 
-    # 썸네일이 트리거한 경우 무시
-    if key.startswith("thumbnail/"):
-        return {"status": "skipped"}
+        # 썸네일이 트리거한 경우 무시
+        if key.startswith("thumbnail/"):
+            results.append({"status": "skipped", "key": key})
+            continue
 
-    # 크기 초과 시 삭제
-    if size > MAX_SIZE_BYTES:
-        print(f"File too large ({size} bytes), deleting: {key}")
-        s3.delete_object(Bucket=bucket, Key=key)
-        return {"status": "deleted", "reason": "file too large"}
+        # 이미지 파일이 아닌 경우 무시
+        ext = os.path.splitext(key)[1].lower()
+        if ext not in ALLOWED_EXTENSIONS:
+            print(f"Not an image file, skipping: {key}")
+            results.append({"status": "skipped", "key": key})
+            continue
 
-    # 썸네일 생성
-    response = s3.get_object(Bucket=bucket, Key=key)
-    image_data = response['Body'].read()
+        # 크기 초과 시 삭제
+        if size > MAX_SIZE_BYTES:
+            print(f"File too large ({size} bytes), deleting: {key}")
+            s3.delete_object(Bucket=bucket, Key=key)
+            results.append({"status": "deleted", "reason": "file too large", "key": key})
+            continue
 
-    image = Image.open(io.BytesIO(image_data))
-    image.thumbnail(THUMBNAIL_SIZE)
+        # 썸네일 생성
+        response = s3.get_object(Bucket=bucket, Key=key)
+        image_data = response['Body'].read()
 
-    if image.mode in ("RGBA", "P"):
-        image = image.convert("RGB")
+        image = Image.open(io.BytesIO(image_data))
+        image.thumbnail(THUMBNAIL_SIZE)
 
-    buffer = io.BytesIO()
-    image.save(buffer, format="JPEG", quality=85)
-    buffer.seek(0)
+        if image.mode in ("RGBA", "P"):
+            image = image.convert("RGB")
 
-    # feed-images/uuid.jpg -> thumbnail/feed-images/uuid.jpg
-    thumbnail_key = "thumbnail/" + key
+        buffer = io.BytesIO()
+        image.save(buffer, format="JPEG", quality=85)
+        buffer.seek(0)
 
-    s3.put_object(
-        Bucket=bucket,
-        Key=thumbnail_key,
-        Body=buffer,
-        ContentType="image/jpeg"
-    )
+        # feed-images/uuid.jpg -> thumbnail/feed-images/uuid.jpg
+        thumbnail_key = "thumbnail/" + key
 
-    print(f"Thumbnail created: {thumbnail_key}")
-    return {"status": "success", "thumbnail_key": thumbnail_key}
+        s3.put_object(
+            Bucket=bucket,
+            Key=thumbnail_key,
+            Body=buffer,
+            ContentType="image/jpeg"
+        )
+
+        print(f"Thumbnail created: {thumbnail_key}")
+        results.append({"status": "success", "thumbnail_key": thumbnail_key})
+
+    return results

--- a/terraform/lambda/image_processor/index.py
+++ b/terraform/lambda/image_processor/index.py
@@ -46,21 +46,18 @@ def handler(event, context):
         image = Image.open(io.BytesIO(image_data))
         image.thumbnail(THUMBNAIL_SIZE)
 
-        if image.mode in ("RGBA", "P"):
-            image = image.convert("RGB")
-
         buffer = io.BytesIO()
-        image.save(buffer, format="JPEG", quality=85)
+        image.save(buffer, format=image.format or "JPEG")
         buffer.seek(0)
 
-        # feed-images/uuid.jpg -> thumbnail/feed-images/uuid.jpg
+        # feed-images/uuid.png -> thumbnail/feed-images/uuid.png
         thumbnail_key = "thumbnail/" + key
 
         s3.put_object(
             Bucket=bucket,
             Key=thumbnail_key,
             Body=buffer,
-            ContentType="image/jpeg"
+            ContentType=f"image/{(image.format or 'jpeg').lower()}"
         )
 
         print(f"Thumbnail created: {thumbnail_key}")

--- a/terraform/lambda/image_processor/index.py
+++ b/terraform/lambda/image_processor/index.py
@@ -43,24 +43,30 @@ def handler(event, context):
         response = s3.get_object(Bucket=bucket, Key=key)
         image_data = response['Body'].read()
 
-        image = Image.open(io.BytesIO(image_data))
-        image.thumbnail(THUMBNAIL_SIZE)
-
         buffer = io.BytesIO()
-        image.save(buffer, format=image.format or "JPEG")
-        buffer.seek(0)
+        try:
+            image = Image.open(io.BytesIO(image_data))
+            image.thumbnail(THUMBNAIL_SIZE)
 
-        # feed-images/uuid.png -> thumbnail/feed-images/uuid.png
-        thumbnail_key = "thumbnail/" + key
+            image.save(buffer, format=image.format or "JPEG")
+            buffer.seek(0)
 
-        s3.put_object(
-            Bucket=bucket,
-            Key=thumbnail_key,
-            Body=buffer,
-            ContentType=f"image/{(image.format or 'jpeg').lower()}"
-        )
+            # feed-images/uuid.png -> thumbnail/feed-images/uuid.png
+            thumbnail_key = "thumbnail/" + key
 
-        print(f"Thumbnail created: {thumbnail_key}")
-        results.append({"status": "success", "thumbnail_key": thumbnail_key})
+            s3.put_object(
+                Bucket=bucket,
+                Key=thumbnail_key,
+                Body=buffer,
+                ContentType=f"image/{(image.format or 'jpeg').lower()}"
+            )
+
+            print(f"Thumbnail created: {thumbnail_key}")
+            results.append({"status": "success", "thumbnail_key": thumbnail_key})
+        except Exception as e:
+            print(f"Failed to process image {key}: {e}")
+            results.append({"status": "error", "key": key, "reason": str(e)})
+        finally:
+            buffer.close()
 
     return results

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -183,8 +183,6 @@ resource "aws_security_group" "fastapi" {
     }
 }
 
-# 기존 Key Pair 사용
-
 # EC2 Instance - Nginx
 resource "aws_instance" "nginx" {
     ami           = var.ami_id

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,57 +1,67 @@
 output "vpc_id" {
-  description = "VPC ID"
-  value       = aws_vpc.main.id
+    description = "VPC ID"
+    value       = aws_vpc.main.id
 }
 
 output "public_subnet_id" {
-  description = "Public Subnet ID"
-  value       = aws_subnet.public.id
+    description = "Public Subnet ID"
+    value       = aws_subnet.public.id
 }
 
 output "nginx_public_ip" {
-  description = "Nginx server public IP"
-  value       = aws_instance.nginx.public_ip
+    description = "Nginx server public IP"
+    value       = aws_instance.nginx.public_ip
 }
 
 output "nginx_private_ip" {
-  description = "Nginx server private IP"
-  value       = aws_instance.nginx.private_ip
+    description = "Nginx server private IP"
+    value       = aws_instance.nginx.private_ip
 }
 
 output "main_server_public_ip" {
-  description = "Main server public IP (for DataGrip connection)"
-  value       = aws_instance.main_server.public_ip
+    description = "Main server public IP (for DataGrip connection)"
+    value       = aws_instance.main_server.public_ip
 }
 
 output "main_server_private_ip" {
-  description = "Main server private IP"
-  value       = aws_instance.main_server.private_ip
+    description = "Main server private IP"
+    value       = aws_instance.main_server.private_ip
 }
 
 output "fastapi_public_ip" {
-  description = "FastAPI server public IP"
-  value       = aws_instance.fastapi.public_ip
+    description = "FastAPI server public IP"
+    value       = aws_instance.fastapi.public_ip
 }
 
 output "fastapi_private_ip" {
-  description = "FastAPI server private IP"
-  value       = aws_instance.fastapi.private_ip
+    description = "FastAPI server private IP"
+    value       = aws_instance.fastapi.private_ip
 }
 
 output "ssh_commands" {
-  description = "SSH commands for each server"
-  value = {
-    nginx   = "ssh -i ~/.ssh/your-key ubuntu@${aws_instance.nginx.public_ip}"
-    main    = "ssh -i ~/.ssh/your-key ubuntu@${aws_instance.main_server.public_ip}"
-    fastapi = "ssh -i ~/.ssh/your-key ubuntu@${aws_instance.fastapi.public_ip}"
-  }
+    description = "SSH commands for each server"
+    value = {
+        nginx   = "ssh -i ~/.ssh/your-key ubuntu@${aws_instance.nginx.public_ip}"
+        main    = "ssh -i ~/.ssh/your-key ubuntu@${aws_instance.main_server.public_ip}"
+        fastapi = "ssh -i ~/.ssh/your-key ubuntu@${aws_instance.fastapi.public_ip}"
+    }
 }
 
 output "datagrip_connection" {
-  description = "DataGrip connection info for Main server DB"
-  value = {
-    host          = aws_instance.main_server.public_ip
-    postgres_port = 5432
-    mysql_port    = 3306
-  }
+    description = "DataGrip connection info for Main server DB"
+    value = {
+        host          = aws_instance.main_server.public_ip
+        postgres_port = 5432
+        mysql_port    = 3306
+    }
+}
+
+output "lambda_function_names" {
+    description = "Lambda function names"
+    value       = {for k, v in aws_lambda_function.functions : k => v.function_name}
+}
+
+output "lambda_function_arns" {
+    description = "Lambda function ARNs"
+    value       = {for k, v in aws_lambda_function.functions : k => v.arn}
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,41 +1,47 @@
 variable "aws_region" {
-  description = "AWS region"
-  type        = string
-  default     = "ap-northeast-2" # 서울 리전
+    description = "AWS region"
+    type        = string
+    default     = "ap-northeast-2" # 서울 리전
 }
 
 variable "project_name" {
-  description = "Project name for resource naming"
-  type        = string
-  default     = "zzan"
+    description = "Project name for resource naming"
+    type        = string
+    default     = "zzan"
 }
 
 variable "key_name" {
-  description = "Existing AWS Key Pair name"
-  type        = string
-  default     = "zzan-rsa-key"
+    description = "Existing AWS Key Pair name"
+    type        = string
+    default     = "zzan-rsa-key"
 }
 
 variable "ami_id" {
-  description = "AMI ID for EC2 instances"
-  type        = string
-  default     = "ami-0c9c942bd7bf113a2" # Ubuntu 22.04 LTS (ap-northeast-2)
+    description = "AMI ID for EC2 instances"
+    type        = string
+    default     = "ami-0c9c942bd7bf113a2" # Ubuntu 22.04 LTS (ap-northeast-2)
 }
 
 variable "nginx_instance_type" {
-  description = "Instance type for Nginx server"
-  type        = string
-  default     = "t3.micro"
+    description = "Instance type for Nginx server"
+    type        = string
+    default     = "t3.micro"
 }
 
 variable "main_instance_type" {
-  description = "Instance type for Main server (Spring Boot + DB + Redis)"
-  type        = string
-  default     = "t3.small"
+    description = "Instance type for Main server (Spring Boot + DB + Redis)"
+    type        = string
+    default     = "t3.small"
 }
 
 variable "fastapi_instance_type" {
-  description = "Instance type for FastAPI server"
-  type        = string
-  default     = "t3.micro"
+    description = "Instance type for FastAPI server"
+    type        = string
+    default     = "t3.micro"
+}
+
+variable "bucket_name" {
+    description = "S3 bucket name for image storage"
+    type        = string
+    default     = "zzan-liquor-bucket"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,5 +43,4 @@ variable "fastapi_instance_type" {
 variable "bucket_name" {
     description = "S3 bucket name for image storage"
     type        = string
-    default     = "zzan-liquor-bucket"
 }


### PR DESCRIPTION
## 변경 사항 요약

S3 업로드 이미지에 대한 크기 제한 및 썸네일 자동 생성 기능을 AWS Lambda를 활용해 구현했습니다.
PresignedUrl은 PUT 방식을 유지하며, 클라이언트 체크 + Lambda 삭제로 크기 제한을 처리합니다.

## 관련 이슈

- Closes #3

## 구현 내용

- `terraform/lambda/image_processor/index.py` — S3 업로드 이벤트 트리거로 20MB 초과 시 자동 삭제, 300x300 JPEG 썸네일 생성 후 `thumbnail/` 경로에 저장
- `terraform/lambda.tf` — Lambda 함수 및 IAM 역할/정책, S3 트리거 설정
- `terraform/variables.tf` — 이미지 저장용 S3 버킷 이름 변수 추가

## 추가 정보

- PresignedUrl 크기 제한은 클라이언트 체크 + Lambda 사후 삭제 방식으로 처리합니다. (PUT presigned URL은 서버 사이드 `content-length-range` 정책 미지원)
- 썸네일 경로: `{원본 경로}` → `thumbnail/{원본 경로}`
- Lambda 환경 변수 `MAX_SIZE_BYTES` 기본값: 20MB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이미지 업로드 시 자동 썸네일(300x300) 생성, 확장자·크기 검사 시행, 용량 초과 파일 자동 삭제(기본 20MB), 처리 결과를 반환.

* **Chores**
  * 서버리스 이미지 처리 인프라와 관련 입력/출력 설정이 추가됨(함수 배포·권한·버킷 트리거 포함).
  * 코드리뷰 설정이 경로별 규칙·필터 중심으로 재구성되고 검토 프로필이 변경됨.
  * 버전관리 규칙에 ZIP 파일 무시 패턴 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->